### PR TITLE
Performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,6 +488,30 @@ checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
 ]
 
 [[package]]
@@ -1102,6 +1140,15 @@ name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1750,6 +1797,7 @@ dependencies = [
  "async-recursion",
  "bcrypt",
  "chrono",
+ "crossbeam",
  "crossbeam-channel",
  "futures",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ bcrypt = "0.10"
 rand = "0.8.4"
 chrono = "0.4.19"
 crossbeam-channel = "0.5.1"
+crossbeam = "0.8.1"
 hyper = { version = "0.14.9", features = ["full"] }
 tokio = { version = "1.7.1", features = ["full"] }
 hyper-tungstenite = "0.3.3"

--- a/src/api_manager/models.rs
+++ b/src/api_manager/models.rs
@@ -329,7 +329,7 @@ impl PrintInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StateWrapper {
     pub state: BridgeState,
     pub description: StateDescription,

--- a/src/api_manager/websocket_handler.rs
+++ b/src/api_manager/websocket_handler.rs
@@ -1,0 +1,215 @@
+use futures::{FutureExt, SinkExt, StreamExt};
+use hyper::upgrade::Upgraded;
+use hyper_tungstenite::tungstenite::{
+    protocol::{frame::coding::CloseCode, CloseFrame},
+    Message,
+};
+use hyper_tungstenite::WebSocketStream;
+use serde_json::{json, Value};
+use std::{collections::HashMap, sync::Arc};
+use tokio::{sync::Mutex, task::yield_now};
+use uuid::Uuid;
+
+use crate::{
+    api_manager::models::{self},
+    bridge::BridgeState,
+};
+
+use super::models::{AuthPermissions, StateWrapper};
+/*
+    Function gets called by the router after the request has been upgraded to a websocket connection.
+    The function keeps loaded as long as a connection is created
+
+
+    Arguments:
+    - websocket: The websocket object
+    - user: parsed user including permissions.
+    - receiver: Global receiver to catch events related to websockets.
+    - state: current state arc, used for sending intial ready event.
+    - sockets: hashmap including all websocket senders, mapped by uuid.
+
+*/
+pub async fn handler(
+    websocket: WebSocketStream<Upgraded>,
+    user: AuthPermissions,
+    state: Arc<Mutex<StateWrapper>>,
+    sockets: Arc<Mutex<HashMap<u128, WebSocketStream<Upgraded>>>>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let id = Uuid::new_v4();
+    {
+        sockets.lock().await.insert(id.clone().as_u128(), websocket);
+
+        println!(
+            "[WS][CONNECTION] ID: {} | User: {}",
+            id.to_hyphenated(),
+            &user.username()
+        );
+    }
+
+    /*
+            Construct intial ready event message.
+    */
+    let mut json = json!({
+                    "type":"ready",
+                    "content": {}
+    });
+    let content = json.get_mut("content").unwrap();
+    let user = json!({
+    "username": user.username(),
+    "permissions" : {
+             "admin": user.admin() ,
+             "connection.edit": user.edit_connection(),
+             "file.access": user.file_access(),
+             "file.edit": user.file_edit(),
+             "print_state.edit": user.print_state_edit(),
+             "settings.edit": user.settings_edit(),
+             "permissions.edit": user.users_edit(),
+             "terminal.read": user.terminal_read(),
+             "terminal.send": user.terminal_send(),
+             "webcam.view": user.webcam(),
+             "update.check": user.update(),
+             "update.manage": user.update()
+            }
+    });
+    let state_info = state.lock().await;
+    let state_info = state_info.clone();
+
+    match state_info.state {
+        BridgeState::DISCONNECTED => {
+            *content = json!({
+                    "user": user,
+                    "state": "Disconnected",
+            });
+        }
+        BridgeState::CONNECTING => {
+            *content = json!({
+                    "user": user,
+                    "state": "Connecting",
+            });
+        }
+        BridgeState::CONNECTED => {
+            *content = json!({
+                    "user": user,
+                    "state": "Connected",
+            });
+        }
+        BridgeState::ERRORED => {
+            let description = match state_info.description.clone() {
+                models::StateDescription::Error { message } => message,
+                _ => "Unknown error".to_string(),
+            };
+
+            *content = json!({
+                    "user": user,
+                    "state": "Errored",
+                    "description": {
+                            "errorDescription": description
+                    }
+            });
+        }
+        BridgeState::PREPARING => todo!(),
+        BridgeState::PRINTING => {
+            let description = match state_info.description.clone() {
+                models::StateDescription::Print {
+                    filename,
+                    progress,
+                    start,
+                    end,
+                } => {
+                    let mut end_string = None;
+                    if end.is_some() {
+                        end_string = Some(end.unwrap().to_rfc3339());
+                    }
+                    json!({
+                            "printInfo": {
+                                    "file": {
+                                            "name": filename,
+                                    },
+                            "progress": format!("{:.2}", progress),
+                            "startTime": start.to_rfc3339(),
+                            "estEndTime": end_string
+                    }})
+                }
+                _ => Value::Null,
+            };
+            *content = json!({
+                    "user": user,
+                    "state": "Printing",
+                    "description": description
+            });
+        }
+        BridgeState::FINISHING => todo!(),
+    };
+    let mut guard = sockets.lock().await;
+    let socket = guard.get_mut(&id.as_u128());
+    if socket.is_some() {
+        let socket = socket.unwrap();
+
+        socket
+            .send(Message::text(json.to_string()))
+            .await
+            .expect("Cannot send message");
+    }
+    return Ok(());
+}
+
+pub async fn check_incoming_messages(
+    sockets: Arc<Mutex<HashMap<u128, WebSocketStream<Upgraded>>>>,
+) {
+    let mut delete_queue: Vec<u128> = vec![];
+    for socket in sockets.lock().await.iter_mut() {
+        let id = socket.0;
+        let socket = socket.1;
+        if let Some(result) = socket.next().now_or_never() {
+            if result.is_none() {
+                yield_now().await;
+                continue;
+            }
+            let result = result.unwrap();
+
+            match result {
+                Ok(message) => {
+                    if message.is_close() {
+                        delete_queue.push(id.clone());
+                        continue;
+                    }
+                    if message.is_ping() {
+                        socket
+                            .send(Message::Pong(message.into_data()))
+                            .await
+                            .expect("Cannot send message");
+                        continue;
+                    }
+
+                    close_socket(id, socket, CloseCode::Unsupported).await;
+                }
+                Err(_) => {
+                    close_socket(id, socket, CloseCode::Error).await;
+                }
+            }
+        }
+    }
+
+    let mut sockets = sockets.lock().await;
+    for id in delete_queue {
+        {
+            let socket = sockets.get_mut(&id);
+            if socket.is_none() {
+                continue;
+            }
+            let socket = socket.unwrap();
+            close_socket(&id, socket, CloseCode::Normal).await;
+        }
+        sockets.remove(&id);
+    }
+}
+
+async fn close_socket(id: &u128, socket: &mut WebSocketStream<Upgraded>, close_code: CloseCode) {
+    println!("[WS][DISCONNECT] ID: {}", &id);
+    let _ = socket
+        .send(Message::Close(Some(CloseFrame {
+            code: close_code,
+            reason: std::borrow::Cow::Borrowed(""),
+        })))
+        .await;
+}

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -78,6 +78,7 @@ impl Bridge {
         let port_result = serialport::new(&self.address, self.baudrate).open();
         if port_result.is_err() {
             let err = port_result.err().unwrap();
+
             match err.kind {
                 serialport::ErrorKind::NoDevice => {
                     self.distibutor
@@ -151,8 +152,9 @@ impl Bridge {
         let ready_for_input = is_ready_for_input.clone();
         spawn(async move {
             let mut outgoing = outgoing_for_listener;
+
             println!(
-                "[Bridge] connected to port {} with {} baudrate",
+                "[BRIDGE] connected to port {} with {} baudrate",
                 outgoing.as_ref().name().unwrap_or("UNNAMED".to_string()),
                 outgoing.as_ref().baud_rate().unwrap()
             );
@@ -418,6 +420,7 @@ impl Bridge {
                             if *is_canceled.lock().unwrap() {
                                 break;
                             }
+
                             eprintln!("[BRIDGE][ERROR][READ]: {:?}", e);
                             cloned_dist
                                 .send(EventInfo {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,24 @@
-use std::sync::{Arc, Mutex};
+use std::{collections::HashMap, sync::{Arc}, time::Duration};
 
-use crate::{
-    api_manager::models::{EventInfo, EventType, WebsocketEvents},
-    bridge::BridgeState,
-};
-use api_manager::{
-    models::{BridgeEvents, SettingRow},
-    ApiManager,
-};
+use crate::{api_manager::{ models::{EventInfo, EventType, StateWrapper, WebsocketEvents}}, bridge::BridgeState};
+use api_manager::{ApiManager, models::{BridgeEvents, SettingRow, StateDescription}};
 
 use bridge::Bridge;
+use chrono::{DateTime, Utc};
 use crossbeam_channel::{unbounded, Sender};
+use futures::SinkExt;
+use hyper::upgrade::Upgraded;
+use hyper_tungstenite::{WebSocketStream, tungstenite::Message};
+use serde_json::json;
 use sqlx::{Connection, Executor, SqliteConnection};
-use tokio::{fs::OpenOptions, spawn, task::{yield_now, JoinHandle}, time::{Instant, sleep}};
+use tokio::{fs::OpenOptions, spawn, task::{yield_now, JoinHandle}, time::{Instant, sleep}, sync::Mutex};
+use uuid::Uuid;
 mod api_manager;
 mod bridge;
 mod client_update_check;
 mod parser;
 
-#[tokio::main]
-// #[tokio::main(worker_threads = 1)]
+#[tokio::main(worker_threads = 1)]
 async fn main() {
     let _guard = sentry::init((
         "https://2a3db3e9cab34ab2996414dd5bf6e169@o229745.ingest.sentry.io/5843753",
@@ -38,14 +37,17 @@ async fn main() {
 
 struct Manager {
     bridge_thread: Option<JoinHandle<()>>,
-    state: Arc<Mutex<BridgeState>>
+    state: Arc<Mutex<StateWrapper>>
 }
 
 impl Manager {
     fn new() -> Self {
         Self {
             bridge_thread: None,
-            state: Arc::new(Mutex::new(BridgeState::DISCONNECTED))
+            state: Arc::new(Mutex::new(StateWrapper {
+                state: BridgeState::DISCONNECTED,
+                description: StateDescription::None,
+            }))
         }
     }
 
@@ -53,13 +55,23 @@ impl Manager {
         let (dist_sender, dist_receiver) = unbounded();
 
         let dist_sender_clone = dist_sender.clone();
-        let (ws_sender, ws_receiver) = unbounded();
         let (bridge_sender, bridge_receiver) = unbounded();
+        
+        let sockets: Arc<tokio::sync::Mutex<HashMap<u128, WebSocketStream<Upgraded>>>> =
+            Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let sockets_clone = sockets.clone();
+        let state = self.state.clone();
         spawn(async move {
-            let _ = spawn(ApiManager::start(dist_sender_clone, ws_receiver));
+            let _ = spawn(ApiManager::start(dist_sender_clone,  sockets_clone, state));
         });
         self.connect_boot(&dist_sender).await;
-        
+        let sockets_clone = sockets.clone();
+        spawn (async move {
+            loop{
+                api_manager::websocket_handler::check_incoming_messages(sockets_clone.clone()).await;
+                sleep(Duration::from_secs(1)).await;
+            };
+        });
         loop {
             if let Ok(event) = dist_receiver.try_recv() {
                 match event.event_type {
@@ -98,7 +110,11 @@ impl Manager {
                         api_manager::models::BridgeEvents::ConnectionCreateError { error },
                     ) => {
                         eprintln!("[BRIDGE] Creating connection caused an error: {} ", error);
-
+                        dist_sender
+                        .send(EventInfo {
+                            event_type: EventType::KILL,
+                        })
+                        .expect("Cannot send message");
                         dist_sender
                             .send(EventInfo {
                                 event_type: EventType::Websocket(WebsocketEvents::StateUpdate {
@@ -163,7 +179,10 @@ impl Manager {
                         state,
                         description,
                     }) => {
-                        *self.state.lock().unwrap() = state;
+                        *self.state.lock().await = StateWrapper {
+                            state,
+                            description: description.clone()
+                        };
                         if self.bridge_thread.is_none() {
                             continue;
                         }
@@ -197,20 +216,194 @@ impl Manager {
                             })
                             .expect("Cannot send message");
                     }
-                    EventType::Websocket(ws_event) => {
-                        ws_sender
-                            .send(EventInfo {
-                                event_type: EventType::Websocket(ws_event),
-                            })
-                            .expect("Failed to send message to websocket");
+                    
+                    EventType::Websocket(WebsocketEvents::TempUpdate {
+                        tools,
+                        bed,
+                        chamber,
+                    }) => {
+                        let json = json!({
+                                "type": "temperature_change",
+                                "content": {
+                                        "tools": tools,
+                                        "bed": bed,
+                                        "chamber": chamber,
+                                        "time": Utc::now().timestamp_millis()
+                                },
+                        });
+                        let mut delete_queue: Vec<u128> = vec![];
+                        for sender in sockets.lock().await.iter_mut() {
+                            let result = sender
+                                .1
+                                .send(Message::text(json.to_string())).await;
+
+                            if result.is_err() {
+                                println!("[WS][ERROR] ID: {} | {}", Uuid::from_u128(sender.0.clone()).to_hyphenated(), result.unwrap_err());
+                                delete_queue.push(sender.0.clone());
+                            }
+                        }
+                        for id in delete_queue {
+                            let mut guard = sockets.lock().await;
+                            guard.remove(&id);
+                        }
                     }
-                    _ => (),
+                    EventType::Websocket(WebsocketEvents::TerminalRead {
+                        message,
+                    }) => {
+                        let time: DateTime<Utc> = Utc::now();
+                        let json = json!({
+                                "type": "terminal_message",
+                                "content": [
+                                        {
+                                                "message": message,
+                                                "type": "OUTPUT",
+                                                "id": null,
+                                                "time": time.to_rfc3339()
+                                        }
+                                ]
+                        });
+                        for sender in sockets.lock().await.iter_mut() {
+                            let result = sender.1.send(Message::text(json.to_string())).await;
+                            if result.is_err() {
+                                println!(
+                                    "[WS] Connection closed: {}",
+                                    Uuid::from_u128(sender.0.clone()).to_hyphenated()
+                                );
+                                sockets.lock().await.remove(sender.0);
+                            }
+                        }
+                    }
+                    EventType::Websocket(WebsocketEvents::TerminalSend {
+                        message,
+                        id,
+                    }) => {
+                        let time: DateTime<Utc> = Utc::now();
+                        let json = json!({
+                                "type": "terminal_message",
+                                "content": [
+                                        {
+                                                "message": message.trim_end(),
+                                                "type": "INPUT",
+                                                "id": id.to_hyphenated().to_string(),
+                                                "time": time.to_rfc3339()
+                                        }
+                                ]
+                        });
+                        for sender in sockets.lock().await.iter_mut() {
+                            sender
+                                .1
+                                .send(Message::text(json.to_string())).await
+                                .expect("Cannot send message");
+                        }
+                    }
+
+                    EventType::Websocket(WebsocketEvents::StateUpdate {
+                        state,
+                        description,
+                    }) => {
+                        let json = match state {
+                            BridgeState::DISCONNECTED => json!({
+                                    "type": "state_update",
+                                    "content": {
+                                            "state": "Disconnected",
+                                            "description": serde_json::Value::Null
+                                    }
+                            })
+                            .to_string(),
+                            BridgeState::CONNECTING => json!({
+                                    "type": "state_update",
+                                    "content": {
+                                            "state": "Connecting",
+                                            "description": serde_json::Value::Null
+                                    }
+                            })
+                            .to_string(),
+                            BridgeState::CONNECTED => json!({
+                                    "type": "state_update",
+                                    "content": {
+                                            "state": "Connected",
+                                            "description": serde_json::Value::Null
+                                    }
+                            })
+                            .to_string(),
+                            BridgeState::ERRORED => match description {
+                                StateDescription::Error { message } => json!({
+                                        "type": "state_update",
+                                        "content": {
+                                                "state": "Errored",
+                                                "description": {
+                                                        "errorDescription": message
+                                                }
+                                        }
+                                })
+                                .to_string(),
+                                _ => json!({
+                                        "type": "state_update",
+                                        "content": {
+                                                "state": "Errored",
+                                                "description": serde_json::Value::Null
+                                        }
+                                })
+                                .to_string(),
+                            },
+                            BridgeState::PREPARING => todo!(),
+                            BridgeState::PRINTING => match description {
+                                StateDescription::Print {
+                                    filename,
+                                    progress,
+                                    start,
+                                    end,
+                                } => {
+                                    let mut end_string: Option<String> = None;
+                                    if end.is_some() {
+                                        end_string = Some(end.unwrap().to_rfc3339());
+                                    }
+                                    json!({
+																			"type": "state_update",
+																			"content": {
+																					"state": "Printing",
+																					"description": {
+																							"printInfo": {
+																									"file": {
+																											"name": filename,
+																									},
+																									"progress": format!("{:.2}", progress),
+																									"startTime": start.to_rfc3339(),
+																									"estEndTime": end_string
+																							}
+																					}
+																			}
+																	})
+																	.to_string()
+                                }
+                                _ => json!({
+                                        "type": "state_update",
+                                        "content": {
+                                                "state": "Printing",
+                                                "description": serde_json::Value::Null
+                                        }
+                                })
+                                .to_string(),
+                            },
+                            BridgeState::FINISHING => todo!(),
+                        };
+                        for sender in sockets.lock().await.iter_mut() {
+                            sender
+                                .1
+                                .send(Message::text(json.to_string())).await
+                                .expect("Cannot send message");
+                        }
+                    }
+                    EventType::KILL => (),
                 }
             } else {
                 let time = Instant::now();
                 yield_now().await;
-                if self.state.lock().unwrap().ne(&BridgeState::PRINTING) && time.elapsed().as_millis() < 200 {
-                    sleep(tokio::time::Duration::from_millis(200 - time.elapsed().as_millis() as u64)).await;
+                let state = self.state.lock().await.state;
+                if state.ne(&BridgeState::PRINTING) && time.elapsed().as_millis() < 500 {
+                    sleep(tokio::time::Duration::from_millis(500 - time.elapsed().as_millis() as u64)).await;
+                }else if state.eq(&BridgeState::PRINTING) && time.elapsed().as_millis() < 5 {
+                    sleep(tokio::time::Duration::from_millis(5 - time.elapsed().as_millis() as u64)).await;
                 }
             }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,8 @@
 use std::{
     collections::VecDeque,
     sync::{Arc, Mutex, MutexGuard},
+    thread::sleep,
+    time::Duration,
 };
 
 use crossbeam_channel::Sender;
@@ -75,6 +77,13 @@ pub fn parse_line(
                     .expect("Cannot send file line");
             }
         }
+    } else if state == BridgeState::PRINTING
+        && input
+            .trim()
+            .to_lowercase()
+            .starts_with("echo:busy: processing")
+    {
+        sleep(Duration::from_secs(1));
     } else if input.to_lowercase().starts_with("error") {
         distributor
             .send(EventInfo {


### PR DESCRIPTION
- Removed event listeners from every websocket connection, improving performance (not having to cycle through the channels).
- Add panic unwinder to bridge, sending error to global channel.
- Add websocket sending to main event loop.
- Todo: split main event loop in seperate handlers, to keep code readable. 