### PR TITLE
Release 0.2.0 | Improving bridge message sending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "server_v2"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-recursion",
  "bcrypt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server_v2"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Tobias Feld <tobias.feld@hotmail.com>"]
 edition = "2018"
 

--- a/src/api_manager.rs
+++ b/src/api_manager.rs
@@ -325,7 +325,6 @@ async fn authenticate_route(request: &Request<Body>) -> Option<AuthPermissions> 
         .unwrap()
         .to_str()
         .expect("Not a valid value");
-
     if token.len() != 60 || !token.chars().all(char::is_alphanumeric) {
         return None;
     }

--- a/src/api_manager/models.rs
+++ b/src/api_manager/models.rs
@@ -1,9 +1,3 @@
-use std::{
-    collections::HashMap,
-    fs::File,
-    io::{BufReader, Lines},
-};
-
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -271,45 +265,52 @@ pub enum BridgeEvents {
 #[derive(Debug)]
 pub struct PrintInfo {
     pub filename: String,
-    pub filesize: u64,
+    pub filesize: usize,
     data_sent: u64,
-    pub file_reader: Option<Lines<BufReader<File>>>,
+    // pub file_reader: Option<Lines<BufReader<File>>>,
+    pub gcode: Vec<String>,
     pub start: DateTime<Utc>,
     pub end: Option<DateTime<Utc>>,
-    line_number: u64,
-    cache: HashMap<u64, String>,
+    line_number: usize,
 }
 
 impl PrintInfo {
     pub fn new(
         filename: String,
-        filesize: u64,
-        file_reader: Option<Lines<BufReader<File>>>,
+        filesize: usize,
+        // file_reader: Option<Lines<BufReader<File>>>,
+        gcode: Vec<String>,
         start: DateTime<Utc>,
     ) -> Self {
         Self {
             filename,
             filesize,
             data_sent: 0,
-            file_reader,
+            gcode,
+            // file_reader,
             start,
             end: None,
             line_number: 0,
-            cache: HashMap::new(),
         }
     }
-
-    pub fn get_sent_line(&self, line_number: u64) -> Option<&String> {
-        return self.cache.get(&line_number);
+    pub fn get_line_by_index(&self, index: usize) -> Option<&String> {
+        return self.gcode.get(index);
     }
-
-    pub fn remove_sent_line(&mut self, line_number: u64) {
-        self.cache.remove(&line_number);
+    pub fn get_next_line(&mut self) -> Option<Line> {
+        let index = self.advance();
+        let line = self.get_line_by_index(index);
+        if line.is_none() {
+            return None;
+        }
+        return Some(Line::new(line.unwrap().clone(), index));
     }
-    pub fn insert_sent_line(&mut self, line_number: u64, line: String) {
-        self.cache.insert(line_number, line);
+    pub fn set_line_number(&mut self, number: usize) -> bool {
+        if number >= self.gcode.len() {
+            return false;
+        }
+        self.line_number = number;
+        return true;
     }
-
     pub fn progress(&self) -> f64 {
         if self.filesize == 0 {
             return 0.0;
@@ -323,9 +324,34 @@ impl PrintInfo {
         }
         self.data_sent = self.data_sent + bytes;
     }
-    pub fn advance(&mut self) -> u64 {
+    pub fn advance(&mut self) -> usize {
         self.line_number += 1;
         return self.line_number;
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Line {
+    content: String,
+    line_number: usize,
+}
+
+impl Line {
+    pub fn new(content: String, line_number: usize) -> Self {
+        Self {
+            content,
+            line_number,
+        }
+    }
+
+    /// Get a reference to the line's line.
+    pub fn content(&self) -> &str {
+        self.content.as_str()
+    }
+
+    /// Get a reference to the line's line number.
+    pub fn line_number(&self) -> &usize {
+        &self.line_number
     }
 }
 

--- a/src/api_manager/models.rs
+++ b/src/api_manager/models.rs
@@ -311,10 +311,7 @@ impl PrintInfo {
     fn get_line_content_by_index(&self, index: usize) -> Option<&String> {
         return self.gcode.get(index);
     }
-    pub fn get_next_line(&mut self) -> Option<Line> {
-        let index = self.advance();
-        return self.get_line_by_index(index);
-    }
+
     pub fn set_line_number(&mut self, line_number: usize) {
         if line_number > self.gcode.len() + 1 {
             panic!("Cannot set line number out of bounds");
@@ -334,8 +331,8 @@ impl PrintInfo {
         }
         self.data_sent = self.data_sent + bytes;
     }
-    pub fn advance(&mut self) -> usize {
-        self.line_number += 1;
+
+    pub fn line_number(&mut self) -> usize {
         return self.line_number;
     }
 }

--- a/src/api_manager/models.rs
+++ b/src/api_manager/models.rs
@@ -301,6 +301,12 @@ impl PrintInfo {
     pub fn get_resend_ratio(&self) -> f32 {
         return (self.resend_amount as f32 / self.gcode.len() as f32) * 100.0;
     }
+    pub fn get_resend_amount(&self) -> &usize {
+        return &self.resend_amount;
+    }
+    pub fn get_line_amount(&self) -> usize {
+        return self.gcode.len();
+    }
     pub fn get_line_by_index(&self, index: usize) -> Option<Line> {
         let content = self.get_line_content_by_index(index);
         if content.is_none() {

--- a/src/api_manager/models.rs
+++ b/src/api_manager/models.rs
@@ -304,13 +304,6 @@ impl PrintInfo {
         }
         return Some(Line::new(line.unwrap().clone(), index));
     }
-    pub fn set_line_number(&mut self, number: usize) -> bool {
-        if number >= self.gcode.len() {
-            return false;
-        }
-        self.line_number = number;
-        return true;
-    }
     pub fn progress(&self) -> f64 {
         if self.filesize == 0 {
             return 0.0;
@@ -387,5 +380,24 @@ pub struct Message {
 impl Message {
     pub fn new(content: String, id: Uuid) -> Self {
         return Self { content, id };
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum BridgeAction {
+    Continue,
+    Error,
+    Resend(usize),
+}
+
+impl std::fmt::Display for BridgeAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BridgeAction::Continue => write!(f, "Continue"),
+            BridgeAction::Error => write!(f, "Error"),
+            BridgeAction::Resend(line) => {
+                write!(f, "Resend N{}", line)
+            }
+        }
     }
 }

--- a/src/api_manager/models.rs
+++ b/src/api_manager/models.rs
@@ -293,16 +293,19 @@ impl PrintInfo {
             line_number: 0,
         }
     }
-    pub fn get_line_by_index(&self, index: usize) -> Option<&String> {
+    pub fn get_line_by_index(&self, index: usize) -> Option<Line> {
+        let content = self.get_line_content_by_index(index);
+        if content.is_none() {
+            return None;
+        }
+        return Some(Line::new(content.unwrap().clone(), index));
+    }
+    fn get_line_content_by_index(&self, index: usize) -> Option<&String> {
         return self.gcode.get(index);
     }
     pub fn get_next_line(&mut self) -> Option<Line> {
         let index = self.advance();
-        let line = self.get_line_by_index(index);
-        if line.is_none() {
-            return None;
-        }
-        return Some(Line::new(line.unwrap().clone(), index));
+        return self.get_line_by_index(index);
     }
     pub fn progress(&self) -> f64 {
         if self.filesize == 0 {

--- a/src/api_manager/routes/start_print.rs
+++ b/src/api_manager/routes/start_print.rs
@@ -61,9 +61,9 @@ pub async fn handler(
     if filename.is_empty() || !filename.ends_with(".gcode") {
         return bad_request_response();
     }
-    // if state.lock().await.state.ne(&BridgeState::CONNECTED) {
-    //     return forbidden_response();
-    // }
+    if state.lock().await.state.ne(&BridgeState::CONNECTED) {
+        return forbidden_response();
+    }
 
     let path = Path::new("./files/")
         .join(filename)

--- a/src/api_manager/routes/start_print.rs
+++ b/src/api_manager/routes/start_print.rs
@@ -16,7 +16,8 @@ use crate::{
     api_manager::{
         models::{BridgeEvents, EventInfo, EventType, PrintInfo, StateWrapper},
         responses::{
-            bad_request_response, forbidden_response, not_found_response, server_error_response,
+            self, bad_request_response, forbidden_response, not_found_response,
+            server_error_response,
         },
     },
     bridge::BridgeState,
@@ -60,33 +61,58 @@ pub async fn handler(
     if filename.is_empty() || !filename.ends_with(".gcode") {
         return bad_request_response();
     }
-    if state.lock().await.state.ne(&BridgeState::CONNECTED) {
-        return forbidden_response();
-    }
+    // if state.lock().await.state.ne(&BridgeState::CONNECTED) {
+    //     return forbidden_response();
+    // }
 
     let path = Path::new("./files/")
         .join(filename)
         .to_string_lossy()
         .into_owned();
 
-    let file = File::open(path);
+    let file = File::open(path.clone());
 
     if file.is_err() {
         return not_found_response();
     }
     let file = file.unwrap();
-    let meta = file.metadata();
-    if meta.is_err() {
-        return server_error_response();
-    }
-    let size = meta.unwrap().len();
 
     let reader = BufReader::new(file);
     let file_reader = reader.lines();
+    let mut gcode: Vec<String> = Vec::with_capacity(file_reader.count() + 1);
+
+    let file = File::open(path);
+
+    if file.is_err() {
+        return server_error_response();
+    }
+    let file = file.unwrap();
+    let file_reader = BufReader::new(file).lines();
+    let mut size: usize = 0;
+    gcode.push("M110 N0".to_string());
+    for line in file_reader {
+        if line.is_err() {
+            return responses::server_error_response();
+        }
+        let line = line.unwrap();
+
+        let line = line.split_terminator(";").next();
+        if line.is_none() {
+            continue;
+        }
+        let line = line.unwrap().trim();
+        if line.len() == 0 {
+            continue;
+        }
+        size += line.as_bytes().len();
+        gcode.push(line.to_string());
+    }
+    gcode.shrink_to_fit();
+
     distributor
         .send(EventInfo {
             event_type: EventType::Bridge(BridgeEvents::PrintStart {
-                info: PrintInfo::new(filename.to_string(), size, Some(file_reader), Utc::now()),
+                info: PrintInfo::new(filename.to_string(), size, gcode, Utc::now()),
             }),
         })
         .expect("Couldn't send message");

--- a/src/api_manager/websocket_handler.rs
+++ b/src/api_manager/websocket_handler.rs
@@ -184,7 +184,7 @@ pub async fn check_incoming_messages(
                     close_socket(id, socket, CloseCode::Unsupported).await;
                 }
                 Err(_) => {
-                    close_socket(id, socket, CloseCode::Error).await;
+                    delete_queue.push(id.clone());
                 }
             }
         }

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -196,7 +196,8 @@ impl Bridge {
                         line = print_info.get_line_by_index(line_number + 1);
                         print_info.set_line_number(line_number);
                     } else {
-                        line = print_info.get_next_line();
+                        // skip line as it's probably just some unrelated echo without line nr.
+                        return;
                     }
                     if line.is_none() {
                         distributor

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -192,7 +192,9 @@ impl Bridge {
                     let print_info = guard.as_mut().unwrap();
                     let line;
                     if line_number.is_some() {
-                        line = print_info.get_line_by_index(line_number.unwrap() + 1);
+                        let line_number = line_number.unwrap();
+                        line = print_info.get_line_by_index(line_number + 1);
+                        print_info.set_line_number(line_number);
                     } else {
                         line = print_info.get_next_line();
                     }

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -195,6 +195,9 @@ impl Bridge {
                         let line_number = line_number.unwrap();
                         line = print_info.get_line_by_index(line_number + 1);
                         print_info.set_line_number(line_number);
+                    } else if print_info.line_number() == 0 {
+                        line = print_info.get_line_by_index(1);
+                        print_info.set_line_number(1);
                     } else {
                         // skip line as it's probably just some unrelated echo without line nr.
                         return;

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -192,7 +192,7 @@ impl Bridge {
                     let print_info = guard.as_mut().unwrap();
                     let line;
                     if line_number.is_some() {
-                        line = print_info.get_line_by_index(line_number.unwrap_or(0));
+                        line = print_info.get_line_by_index(line_number.unwrap() + 1);
                     } else {
                         line = print_info.get_next_line();
                     }

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -530,13 +530,14 @@ impl Bridge {
                                                 let line =
                                                     print_info.get_line_by_index(line_number);
                                                 if line.is_some() {
+                                                    let line = line.unwrap();
                                                     bridge_sender
                                                         .send(EventInfo {
                                                             event_type: EventType::Bridge(
                                                                 BridgeEvents::TerminalSend {
                                                                     message: Parser::add_checksum(
-                                                                        &line_number,
-                                                                        line.unwrap(),
+                                                                        line.line_number(),
+                                                                        line.content(),
                                                                     ),
                                                                     id: Uuid::new_v4(),
                                                                 },

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,8 @@ impl Manager {
 
                         let dist_sender_clone = dist_sender.clone();
                         let bridge_receiver_clone = bridge_receiver.clone();
+                        let bridge_sender_clone = bridge_sender.clone();
+                        let state = self.state.clone();
                         self.bridge_thread = Some(spawn(async move {
                             let panic_sender_clone = dist_sender_clone.clone();
                             std::panic::set_hook(Box::new(move |_| {
@@ -110,11 +112,13 @@ impl Manager {
                             }));
                             let mut bridge = Bridge::new(
                                 dist_sender_clone,
+                                bridge_sender_clone,
                                 bridge_receiver_clone,
                                 address,
                                 port,
+                                state
                             );
-                            bridge.start();
+                            bridge.start().await;
                         }));
                     }
                     EventType::Bridge(

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,8 +100,10 @@ impl Manager {
                         let state = self.state.clone();
                         self.bridge_thread = Some(spawn(async move {
                             let panic_sender_clone = dist_sender_clone.clone();
-                            std::panic::set_hook(Box::new(move |_| {
-                                
+                            std::panic::set_hook(Box::new(move |e| {
+                                println!("[BRIDGE][PANIC] {}", e);
+                                let msg = format!("{}", e);
+                                sentry::capture_message(&msg, sentry::Level::Error);
                                 panic_sender_clone.send(EventInfo { event_type: EventType::Bridge(BridgeEvents::StateUpdate {
                                     state: BridgeState::ERRORED,
                                     description: StateDescription::Error {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -22,6 +22,13 @@ impl Parser {
                         .unwrap(),
                 );
             }
+            if LINENR.is_match(&response) {
+                return BridgeAction::Continue(Some(
+                    LINENR.captures(&response).unwrap()[1]
+                        .parse::<usize>()
+                        .unwrap(),
+                ));
+            }
             if response.starts_with("error") {
                 if !response.starts_with("Error:Line Number is not Last Line Number+1, Last Line: ")
                 {
@@ -29,7 +36,7 @@ impl Parser {
                 }
             }
         }
-        return BridgeAction::Continue;
+        return BridgeAction::Continue(None);
     }
 
     pub fn add_checksum(linenr: &usize, line: &str) -> String {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -17,7 +17,7 @@ impl Parser {
         for response in responses {
             if RESEND.is_match(&response) {
                 return BridgeAction::Resend(
-                    RESEND.captures(&response).unwrap()[0]
+                    RESEND.captures(&response).unwrap()[1]
                         .parse::<usize>()
                         .unwrap(),
                 );


### PR DESCRIPTION
- Rewrote bridge.
- Made event loops way more efficient, so they don't take full cpu power on older / smaller systems. (rpi)
- Cache print files
- Rewrote parser to an read-only handler, so it cannot mess up the order or commands sent.
- Resends are now handled correctly and queued accordingly
- Add logging some print stats on print end.
