### PR TITLE
Change event structure

### DIFF
--- a/src/api_manager.rs
+++ b/src/api_manager.rs
@@ -8,7 +8,7 @@ use crate::api_manager::responses::{
 };
 
 use self::{
-    models::{AuthPermissions, EventInfo, StateWrapper},
+    models::{AuthPermissions, EventType, StateWrapper},
     responses::bad_request_response,
 };
 
@@ -45,7 +45,7 @@ pub struct ApiManager {}
 */
 impl ApiManager {
     pub async fn start(
-        distributor: Sender<EventInfo>,
+        distributor: Sender<EventType>,
         sockets: Arc<Mutex<HashMap<u128, WebSocketStream<Upgraded>>>>,
         state: Arc<Mutex<StateWrapper>>,
     ) -> () {
@@ -90,7 +90,7 @@ impl ApiManager {
 async fn router(
     mut req: Request<Body>,
     file_server: Static,
-    distributor: Sender<EventInfo>,
+    distributor: Sender<EventType>,
     state: Arc<Mutex<StateWrapper>>,
     sockets: Arc<Mutex<HashMap<u128, WebSocketStream<Upgraded>>>>,
 ) -> Result<Response<Body>, Infallible> {
@@ -215,7 +215,7 @@ async fn router(
 */
 async fn handle_route(
     mut request: Request<Body>,
-    distributor: Sender<EventInfo>,
+    distributor: Sender<EventType>,
     state: Arc<Mutex<StateWrapper>>,
 ) -> Response<Body> {
     let path = normalize_url(&request);

--- a/src/api_manager/routes/cancel_print.rs
+++ b/src/api_manager/routes/cancel_print.rs
@@ -10,24 +10,21 @@
 use crossbeam_channel::Sender;
 use hyper::{header, Body, Response};
 
-use crate::{
-    api_manager::{
-        models::{send, BridgeEvents, EventInfo, EventType, StateWrapper},
-        responses::forbidden_response,
-    },
-    bridge::BridgeState,
+use crate::api_manager::{
+    models::{send, BridgeState, EventType, StateWrapper},
+    responses::forbidden_response,
 };
 
 #[allow(dead_code)]
 pub const METHODS: &str = "DELETE";
 pub const PATH: &str = "/api/print";
 
-pub fn handler(state_info: StateWrapper, distributor: Sender<EventInfo>) -> Response<Body> {
+pub fn handler(state_info: StateWrapper, distributor: Sender<EventType>) -> Response<Body> {
     if state_info.state != BridgeState::PRINTING {
         return forbidden_response();
     }
 
-    send(&distributor, EventType::Bridge(BridgeEvents::PrintEnd));
+    send(&distributor, EventType::PrintEnd);
 
     return Response::builder()
         .header(header::CONTENT_TYPE, "text/plain")

--- a/src/api_manager/routes/create_connection.rs
+++ b/src/api_manager/routes/create_connection.rs
@@ -11,19 +11,16 @@ use crossbeam_channel::Sender;
 use hyper::{header, Body, Request, Response};
 use sqlx::{Connection, SqliteConnection};
 
-use crate::{
-    api_manager::{
-        models::{BridgeEvents, EventInfo, EventType, SettingRow, StateWrapper},
-        responses::forbidden_response,
-    },
-    bridge::BridgeState,
+use crate::api_manager::{
+    models::{BridgeState, EventType, SettingRow, StateWrapper},
+    responses::forbidden_response,
 };
 pub const METHODS: &str = "PUT, DELETE, POST";
 pub const PATH: &str = "/api/connection";
 
 pub async fn handler(
     _request: Request<Body>,
-    distributor: Sender<EventInfo>,
+    distributor: Sender<EventType>,
     state_info: StateWrapper,
 ) -> Response<Body> {
     if !(state_info.state == BridgeState::DISCONNECTED || state_info.state == BridgeState::ERRORED)
@@ -76,11 +73,9 @@ pub async fn handler(
     }
 
     distributor
-        .send(EventInfo {
-            event_type: EventType::Bridge(BridgeEvents::ConnectionCreate {
-                address: result.clone().unwrap().address,
-                port: result.unwrap().port,
-            }),
+        .send(EventType::CreateBridge {
+            address: result.clone().unwrap().address,
+            port: result.unwrap().port,
         })
         .expect("Cannot send message");
 

--- a/src/api_manager/routes/disconnect_connection.rs
+++ b/src/api_manager/routes/disconnect_connection.rs
@@ -11,14 +11,11 @@ use crossbeam_channel::Sender;
 use hyper::{header, Body, Response};
 use serde_json::json;
 
-use crate::{
-    api_manager::models::{send, BridgeEvents, EventInfo, EventType, StateDescription},
-    bridge::BridgeState,
-};
+use crate::api_manager::models::{send, BridgeState, EventType, StateDescription, StateWrapper};
 pub const METHODS: &str = "PUT, DELETE, POST";
 pub const PATH: &str = "/api/connection";
 
-pub async fn handler(state: BridgeState, distributor: Sender<EventInfo>) -> Response<Body> {
+pub async fn handler(state: BridgeState, distributor: Sender<EventType>) -> Response<Body> {
     if state.eq(&BridgeState::DISCONNECTED) || state.eq(&BridgeState::ERRORED) {
         return Response::builder()
             .header(header::CONTENT_TYPE, "text/plain")
@@ -33,7 +30,7 @@ pub async fn handler(state: BridgeState, distributor: Sender<EventInfo>) -> Resp
 
     send(
         &distributor,
-        EventType::Bridge(BridgeEvents::StateUpdate {
+        EventType::StateUpdate(StateWrapper {
             state: BridgeState::DISCONNECTED,
             description: StateDescription::None,
         }),

--- a/src/api_manager/websocket_handler.rs
+++ b/src/api_manager/websocket_handler.rs
@@ -10,10 +10,7 @@ use std::{collections::HashMap, sync::Arc};
 use tokio::{sync::Mutex, task::yield_now};
 use uuid::Uuid;
 
-use crate::{
-    api_manager::models::{self},
-    bridge::BridgeState,
-};
+use crate::api_manager::models::{self, BridgeState};
 
 use super::models::{AuthPermissions, StateWrapper};
 /*

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use serde::ser::SerializeStruct;
 
-use crate::api_manager::models::{BridgeAction, WebsocketEvents};
+use crate::api_manager::models::{BridgeAction, EventType};
 
 lazy_static! {
     static ref TOOLTEMPREGEX: Regex = Regex::new(r"((T\d?):([\d\.]+) ?/([\d\.]+))+").unwrap();
@@ -50,7 +50,7 @@ impl Parser {
         return format!("{}*{}", line, cs);
     }
 
-    pub fn parse_temperature(input: &String) -> WebsocketEvents {
+    pub fn parse_temperature(input: &String) -> EventType {
         let mut tools: Vec<TempInfo> = Vec::new();
 
         let mut bed: Option<TempInfo> = None;
@@ -82,7 +82,7 @@ impl Parser {
             let info = TempInfo::new_no_name(current_temp, target_temp);
             chamber = Some(info);
         }
-        return WebsocketEvents::TempUpdate {
+        return EventType::TempUpdate {
             tools,
             bed,
             chamber,


### PR DESCRIPTION
Instead of creating different events for websockets & bridges, we have one enum for all. 